### PR TITLE
Patch #9

### DIFF
--- a/BassClefStudio.LatinClub.Uno.Shared/ViewModels/MainViewModel.cs
+++ b/BassClefStudio.LatinClub.Uno.Shared/ViewModels/MainViewModel.cs
@@ -10,8 +10,6 @@ using System.Collections.Generic;
 using System.Text;
 using BassClefStudio.LatinClub.Uno.Data;
 using System.Threading.Tasks;
-using Microsoft.Toolkit.Uwp.UI;
-
 namespace BassClefStudio.LatinClub.Uno.ViewModels
 {
     public class MainViewModel : Observable
@@ -19,12 +17,12 @@ namespace BassClefStudio.LatinClub.Uno.ViewModels
         private ClubContext context;
         public ClubContext Context { get => context; set => Set(ref context, value); }
 
-        public AdvancedCollectionView EventsView { get; }
+        //public AdvancedCollectionView EventsView { get; }
 
         public MainViewModel()
         {
             Context = new ClubContext();
-            EventsView = new AdvancedCollectionView(Context.Events.Item);
+            //EventsView = new AdvancedCollectionView(Context.Events.Item);
             SetCommand = new RelayCommandBuilder(Set).Command;
         }
 

--- a/BassClefStudio.LatinClub.Uno.Shared/Views/MainPage.xaml
+++ b/BassClefStudio.LatinClub.Uno.Shared/Views/MainPage.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:data="using:BassClefStudio.LatinClub.Uno.Data" 
     mc:Ignorable="d">
-    <Grid 
+    <Grid
         Background="{ThemeResource SystemChromeMediumColor}">
         <StackPanel>
             <Button 
@@ -15,7 +15,7 @@
                 HorizontalAlignment="Center"
                 Command="{x:Bind ViewModel.SetCommand}"/>
             <ListView
-                ItemsSource="{x:Bind ViewModel.EventsView, Mode=OneWay}">
+                ItemsSource="{x:Bind ViewModel.Context.Events.Item, Mode=OneWay}">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="data:EventSyncItem">
                         <Grid>

--- a/BassClefStudio.LatinClub.Uno.UWP/BassClefStudio.LatinClub.Uno.Uwp.csproj
+++ b/BassClefStudio.LatinClub.Uno.UWP/BassClefStudio.LatinClub.Uno.Uwp.csproj
@@ -39,7 +39,7 @@
     <AssemblyName>BassClefStudio.LatinClub.Uno</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/BassClefStudio.LatinClub.Uno.Wasm/BassClefStudio.LatinClub.Uno.Wasm.csproj
+++ b/BassClefStudio.LatinClub.Uno.Wasm/BassClefStudio.LatinClub.Uno.Wasm.csproj
@@ -4,9 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
-    <Version>1.0.1</Version>
-    <Authors>BassClefStudio</Authors>
-    <Company>BassClefStudio</Company>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>
@@ -42,9 +39,9 @@
     <PackageReference Include="BassClefStudio.NET.Sync" Version="1.4.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
-    <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="6.1.0-build.191.gc988bdd4ff" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.5.0-dev.57" />
     <PackageReference Include="Uno.WinUI" Version="3.1.0-dev.747" />
+    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.1.0-dev.747" />
     <PackageReference Include="Uno.WinUI.WebAssembly" Version="3.1.0-dev.747" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.5.0-dev.57" />
   </ItemGroup>

--- a/BassClefStudio.LatinClub.Uno.Wasm/BassClefStudio.LatinClub.Uno.Wasm.csproj
+++ b/BassClefStudio.LatinClub.Uno.Wasm/BassClefStudio.LatinClub.Uno.Wasm.csproj
@@ -43,11 +43,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI" Version="6.1.0-build.191.gc988bdd4ff" />
-    <PackageReference Include="Uno.WinUI" Version="3.1.0-dev.739" />
-    <PackageReference Include="Uno.WinUI.WebAssembly" Version="3.1.0-dev.739" />
-    <PackageReference Include="Uno.WinUI.RemoteControl" Version="3.1.0-dev.739" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.5.0-dev.57" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="1.5.0-dev.57" />
+    <PackageReference Include="Uno.WinUI" Version="3.1.0-dev.747" />
+    <PackageReference Include="Uno.WinUI.WebAssembly" Version="3.1.0-dev.747" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="1.5.0-dev.57" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Assets\" />


### PR DESCRIPTION
Fixes #9 by removing Windows Community Toolkit packages from the Uno project and opting instead for directly accessing the `ObservableCollection`.